### PR TITLE
improved naming for `copyFile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # do-spaces
 
-Unofficial package for simple managing file operations hosted on "Digital Ocean Spaces" written in Typescript
+An unofficial TypeScript package for simple file management operations on DigitalOcean Spaces.
 
-![do-spaces unnoficial package readme banner](https://user-images.githubusercontent.com/8983870/239910462-a037cf98-6bce-4c8b-9399-a4382f6a41c2.png)
+![do-spaces unofficial package readme banner](https://user-images.githubusercontent.com/8983870/239910462-a037cf98-6bce-4c8b-9399-a4382f6a41c2.png)
 
 ### Motivation
 
-I've created this package to ease working with [spaces](https://www.digitalocean.com/products/spaces/). Be more expressive then `aws-sdk`. And to solve "quirks" `aws-sdk` have (like uploading with mime-types, delete whole folder...)
+I've created this package to make working with [Spaces](https://www.digitalocean.com/products/spaces/) easier and more expressive than using `aws-sdk` directly. It also smooths over some of the quirks of `aws-sdk`, like handling MIME types on upload and deleting entire folders.
 
 ### Install
 
@@ -36,69 +36,69 @@ const spaces = new Spaces({
 
 ### Methods
 
-- every method takes **optional** `awsParams` to enhance/replace it's default configuration for underlying method. Configuration docs can be found [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html)
+- every method takes **optional** `awsParams` to enhance/replace its default configuration for the underlying method. Configuration docs can be found [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html)
 - `path` - **string**, path folder like (ending with `/`)
 - `pathname` -- **string**, full path to file (e.g `/test/image.png`)
-- all methods returns `Promise`
+- all methods return a `Promise`
 
 ```js
 const spaces = new Spaces({
-    endpoint: `<endpoint>`, // under settings of bucket in digital ocean
-    accessKey: `<access_key>`, // in GLOBAL settings of digital ocean
-    secret: `<secret>`, // in GLOBAL settings of digital ocean
-    bucket: `<name_of_the_bucket>`,
+  endpoint: `<endpoint>`, // under settings of bucket in digital ocean
+  accessKey: `<access_key>`, // in GLOBAL settings of digital ocean
+  secret: `<secret>`, // in GLOBAL settings of digital ocean
+  bucket: `<name_of_the_bucket>`,
 });
 
-// ....
+// ...
 
 // `s3.putObject`
 await spaces.createFolder({
-    path: `/some/test/path/`,
-    awsParams // optional - `s3.putObject`
+  path: '/some/test/path/',
+  awsParams, // optional - `s3.putObject`
 });
 
-// ....
+// ...
 
 // recursively removes all files in specified folder
 await spaces.deleteFolder({
-  path: `/some/test/path/`,
-  awsListParams, //optional - used to list items before deleting - `s3.listObjects`
+  path: '/some/test/path/',
+  awsListParams, // optional - used to list items before deleting - `s3.listObjects`
   awsDeleteParams, // optional - used to delete `s3.deleteObjects`
 });
 
 // folders are automatically created, no need to create folders beforehand
 // automatically determines mime-type
 await spaces.uploadFile({
-    pathname: `/some/test/path/myfile.txt`,
-    privacy: "public-read", // 'private' | 'public-read' (DO supports only those)
-    file,// Blob, string...
-    awsParams  // optional - `s3.putObject`
+  pathname: '/some/test/path/myfile.txt',
+  privacy: 'public-read', // 'private' | 'public-read' (DO supports only those)
+  file, // Blob, string...
+  awsParams, // optional - `s3.putObject`
 });
 
 await spaces.downloadFile({
-    pathname: "/some/test/path/myfile.txt", // or link https://<bucket>.<endpoint>/path/to/file
-    awsParams // optional -  `s3.getObject`
+  pathname: '/some/test/path/myfile.txt', // or link https://<bucket>.<endpoint>/path/to/file
+  awsParams, // optional -  `s3.getObject`
 });
 
-// if there are more then 1000 files you will receive in response `nextMarker`,
+// if there are more than 1000 files you will receive in response `nextMarker`,
 // to continue with listing
 await spaces.listFiles({
-    maxFiles = 1000, // optional - default is 1000 (max allowed in DO/AWS)
-    path: `/some/test/path/` ,
-    nextMarker, // optional - from which path it should start listing (supplied)
-    awsParams, // optional - `s3.getObjects`
+  maxFiles: 1000, // optional - default is 1000 (max allowed in DO/AWS)
+  path: '/some/test/path/',
+  nextMarker, // optional - from which path it should start listing (supplied)
+  awsParams, // optional - `s3.getObjects`
 });
 
 await spaces.copyFile({
-    targetPathname: "/test/newFile.txt",
-    sourcePathname: "/test/originalFile.txt",
-    privacy: "public-read", // 'private' | 'public-read'
-    fromBucket, // optional - different bucket name if copied from elsewhere
-    awsParams, // optional -`s3.copyObject`
+  targetPathname: '/test/newFile.txt',
+  sourcePathname: '/test/originalFile.txt',
+  privacy: 'public-read', // 'private' | 'public-read'
+  fromBucket, // optional - different bucket name if copied from elsewhere
+  awsParams, // optional -`s3.copyObject`
 });
 
 await spaces.deleteFile({
-    pathname: "/test/remove_me.txt",
-    awsParams // optional `s3.deleteObject`
+  pathname: '/test/remove_me.txt',
+  awsParams, // optional `s3.deleteObject`
 });
 ```

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ await spaces.listFiles({
 });
 
 await spaces.copyFile({
-    pathname: "/test/newFile.txt",
-    copiedPathname: "/test/copied.txt",
+    targetPathname: "/test/newFile.txt",
+    sourcePathname: "/test/originalFile.txt",
     privacy: "public-read", // 'private' | 'public-read'
     fromBucket, // optional - different bucket name if copied from elsewhere
     awsParams, // optional -`s3.copyObject`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ export type UploadFile = {
 };
 
 export type CopyFile = {
-  pathname: string;
-  copiedPathname: string;
+  targetPathname: string;
+  sourcePathname: string;
   privacy: Privacy;
   fromBucket?: string;
   awsParams?: AwsParam;
@@ -196,19 +196,20 @@ export class Spaces {
     return await this.s3.putObject(params).promise();
   }
   public async copyFile({
-    pathname,
-    copiedPathname,
+    targetPathname,
+    sourcePathname,
     privacy,
     fromBucket,
     awsParams,
   }: CopyFile) {
-    const _copyPathname = `/${fromBucket ||
-      this.bucket}/${this._removeLeadingSlash(copiedPathname)}`;
+    const _sourcePathname = `/${
+      fromBucket || this.bucket
+    }/${this._removeLeadingSlash(sourcePathname)}`;
 
     const params = {
       Bucket: this.bucket,
-      Key: this._removeLeadingSlash(pathname),
-      CopySource: _copyPathname,
+      Key: this._removeLeadingSlash(targetPathname),
+      CopySource: _sourcePathname,
       ACL: privacy,
       ...awsParams,
     };


### PR DESCRIPTION
As discussed in https://github.com/maielo/do-spaces/issues/4, this PR introduces a more established naming convention using `targetPathname` and `sourcePathname` in the `copyFile` method. Please note that this is a breaking change, so the version is bumped to 2.0.0.

I've also included a few readme changes in a separate commit but please feel free to revert that if you find them to be unnecessary.